### PR TITLE
feat(warehouse): add warehouse detail page and masonry gallery

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,7 @@
 .read-the-docs {
   color: #888;
 } */
+
+button {
+  cursor: pointer;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import DashboardAdminSede from "./components/pages/dashboardAdminSede";
 import DashboardAdmin from "./components/pages/dashboardAdmin"
 import AuthPage from "./components/pages/Auth";
 import WarehouseGallery from "./components/pages/warehouseGallery";
+import WarehouseDetail from "./components/pages/warehouseDetail";
 
 // Create a wrapper component for the Navbar
 const NavbarWrapper = () => {
@@ -25,10 +26,10 @@ function App() {
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/auth" element={<AuthPage />} />
-        {/* <Route path="/register" element={<MyRegister />} /> */}
         <Route path="/dashboard" element={<DashboardAdminSede/>} />
         <Route path="/admin" element={<DashboardAdmin/>} />
         <Route path="/gallery" element={<WarehouseGallery/>} />
+        <Route path="/warehouse/:id" element={<WarehouseDetail />} />
       </Routes>
     </Router>
   );

--- a/src/components/layout/navbar.jsx
+++ b/src/components/layout/navbar.jsx
@@ -8,44 +8,50 @@ const MyNavbar = () => {
   const [isScrolled, setIsScrolled] = useState(false);
 
   const location = useLocation();
+  const isHome = location.pathname === "/";
   const isGallery = location.pathname === "/gallery";
+  const isDetails = location.pathname.startsWith("/warehouse/");
 
   useEffect(() => {
-    const handleScroll = () => {
-      setIsScrolled(window.scrollY > 50);
-    };
+    if (isHome) {
+      const handleScroll = () => setIsScrolled(window.scrollY > 50);
+      window.addEventListener("scroll", handleScroll);
+      return () => window.removeEventListener("scroll", handleScroll);
+    }
+  }, [isHome]);
 
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  const baseColor =
+    isHome && isScrolled
+      ? "bg-white/70 shadow-md backdrop-blur-lg"
+      : isGallery || isDetails
+      ? "bg-white shadow-md text-gray-900"
+      : "bg-transparent text-white";
 
-  const baseColor = isGallery
-    ? "bg-white shadow-md text-gray-900"
-    : isScrolled
-    ? "bg-white/70 shadow-md backdrop-blur-lg"
-    : "bg-transparent text-white";
+  const textColor =
+    isGallery || isDetails || isScrolled ? "text-gray-900" : "text-white";
 
-  const textColor = isGallery || isScrolled ? "text-gray-900" : "text-white";
+  // 💡 Solo aplicar position: fixed si estamos en la landing
+  const positionStyle = isHome ? "fixed" : "relative";
 
   return (
     <div className="flex flex-col">
       <header
-        className={`fixed top-0 left-0 w-full z-50 transition-all duration-300 ${baseColor}`}
+        className={`${positionStyle} top-0 left-0 w-full z-50 transition-all duration-300 ${baseColor}`}
       >
         <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
           {/* Logo */}
-          <Link to={'/'}>
+          <Link to="/">
             <div className={`flex gap-2 items-center text-2xl ${textColor}`}>
               <Warehouse />
               <span>BodegaSegura</span>
             </div>
           </Link>
 
-          {/* Botón Menú Hamburguesa (Móvil) */}
+          {/* Botón Menú Hamburguesa */}
           <button
             onClick={() => setIsOpen(!isOpen)}
             className={`md:hidden transition-colors duration-300 focus:outline-none ${
-              isGallery || isScrolled ? "text-gray-800" : "text-white"
+              textColor
             }`}
           >
             {isOpen ? <X className="w-8 h-8" /> : <Menu className="w-8 h-8" />}
@@ -53,26 +59,21 @@ const MyNavbar = () => {
 
           {/* Menú Desktop */}
           <nav className="hidden md:flex items-center space-x-6">
-            {["servicios", "catalog", "contacto"].map((section) => (
-              <a
-                key={section}
-                href={`#${section}`}
-                className={`text-sm transition-colors hover:text-blue-600 ${
-                  isGallery || isScrolled ? "text-gray-700" : "text-white"
-                }`}
-              >
-                {section.charAt(0).toUpperCase() + section.slice(1)}
-              </a>
-            ))}
             <Link
-              to={"/auth"}
-              className={`text-sm transition-colors hover:text-blue-600 ${
-                isGallery || isScrolled ? "text-gray-700" : "text-white"
-              }`}
+              to="/gallery"
+              className={`text-sm transition-colors hover:text-blue-600 ${textColor}`}
+            >
+              Galería
+            </Link>
+
+            <Link
+              to="/auth"
+              className={`text-sm transition-colors hover:text-blue-600 ${textColor}`}
             >
               Iniciar sesión
             </Link>
-            <Link to={"/auth"}>
+
+            <Link to="/auth">
               <button className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg shadow-md transition-all duration-300 hover:bg-blue-700 focus:outline-none focus:ring focus:ring-blue-300">
                 Reservar Ahora
               </button>
@@ -80,7 +81,7 @@ const MyNavbar = () => {
           </nav>
         </div>
 
-        {/* Menú Móvil */}
+        {/* Menú móvil */}
         {isOpen && (
           <motion.div
             initial={{ opacity: 0, y: -20 }}
@@ -90,16 +91,13 @@ const MyNavbar = () => {
             className="md:hidden bg-white/90 backdrop-blur-lg shadow-md p-4"
           >
             <nav className="flex flex-col space-y-4 text-center">
-              {["servicios", "catalog", "contacto"].map((section) => (
-                <a
-                  key={section}
-                  href={`#${section}`}
-                  className="text-sm text-gray-700 transition-colors hover:text-blue-600"
-                  onClick={() => setIsOpen(false)}
-                >
-                  {section.charAt(0).toUpperCase() + section.slice(1)}
-                </a>
-              ))}
+              <Link
+                to="/gallery"
+                className="text-sm text-gray-700 transition-colors hover:text-blue-600"
+                onClick={() => setIsOpen(false)}
+              >
+                Galería
+              </Link>
               <Link
                 to="/auth"
                 className="text-sm text-gray-700 transition-colors hover:text-blue-600"
@@ -107,12 +105,11 @@ const MyNavbar = () => {
               >
                 Iniciar sesión
               </Link>
-              <button
-                className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg shadow-md transition-all duration-300 hover:bg-blue-700 focus:outline-none focus:ring focus:ring-blue-300"
-                onClick={() => setIsOpen(false)}
-              >
-                Reservar Ahora
-              </button>
+              <Link to="/auth" onClick={() => setIsOpen(false)}>
+                <button className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg shadow-md transition-all duration-300 hover:bg-blue-700 focus:outline-none focus:ring focus:ring-blue-300">
+                  Reservar Ahora
+                </button>
+              </Link>
             </nav>
           </motion.div>
         )}

--- a/src/components/pages/warehouseDetail.jsx
+++ b/src/components/pages/warehouseDetail.jsx
@@ -1,0 +1,91 @@
+import { useParams } from "react-router-dom";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+const mockWarehouse = {
+  warehouse_id: 1,
+  code: "WH-001",
+  dimensions: "5x4x3 meters",
+  monthly_price: 1500,
+  status: "available",
+  site: {
+    name: "UTEZ",
+    location: "123 Main Street",
+  },
+  photos: [
+    "https://images.unsplash.com/photo-1624927637280-f033784c1279?w=900&auto=format&fit=crop&q=60",
+    "https://images.unsplash.com/photo-1532635042-a6f6ad4745f9?w=900&auto=format&fit=crop&q=60",
+    "https://images.unsplash.com/photo-1565610222536-ef125c59da2e?w=900&auto=format&fit=crop&q=60",
+    "https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=900&auto=format&fit=crop&q=60",
+    "https://images.unsplash.com/photo-1571171637578-41bc2dd41cd2?w=900&auto=format&fit=crop&q=60",
+  ],
+};
+
+export default function WarehouseDetail() {
+  const { id } = useParams();
+  const warehouse = mockWarehouse; // ← luego esto será una petición
+  const [selectedImage, setSelectedImage] = useState(warehouse.photos[0]);
+
+  return (
+    <section className="container mx-auto px-6 py-12 mt-12">
+      <div className="flex flex-col lg:flex-row gap-12">
+        {/* Galería de imágenes */}
+        <div className="w-full lg:w-1/2">
+          <div className="border rounded-lg overflow-hidden">
+            <img
+              src={selectedImage}
+              alt="Warehouse principal"
+              className="w-full h-[400px] object-cover"
+            />
+          </div>
+          <div className="flex gap-2 mt-4 overflow-x-auto">
+            {warehouse.photos.map((img, index) => (
+              <img
+                key={index}
+                src={img}
+                alt={`Vista ${index + 1}`}
+                onClick={() => setSelectedImage(img)}
+                className={`w-24 h-24 object-cover cursor-pointer border rounded-lg ${
+                  selectedImage === img ? "ring-2 ring-blue-600" : ""
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Información de la bodega */}
+        <div className="w-full lg:w-1/2 space-y-4">
+          <span className="text-sm bg-green-100 text-green-800 px-3 py-1 rounded-full uppercase font-medium tracking-wide w-fit">
+            {warehouse.status === "available" ? "Disponible" : "Ocupado"}
+          </span>
+
+          <h2 className="text-3xl font-bold">Bodega {warehouse.code}</h2>
+          <p className="text-gray-600">Ubicación: {warehouse.site.name}</p>
+          <p className="text-gray-600">Dirección: {warehouse.site.location}</p>
+
+          <p className="text-xl font-semibold text-blue-600">
+            ${warehouse.monthly_price} / mes
+          </p>
+
+          <div className="border-t pt-4 mt-4 space-y-2">
+            <p className="text-gray-700">
+              <strong>Dimensiones:</strong> {warehouse.dimensions}
+            </p>
+            <p className="text-gray-700">
+              <strong>Código:</strong> {warehouse.code}
+            </p>
+            <p className="text-gray-700">
+              <strong>Estado:</strong>{" "}
+              {warehouse.status === "available" ? "Disponible" : "Ocupado"}
+            </p>
+          </div>
+          <Link to={'/auth'}>
+            <button className="cursor-pointer mt-6 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 rounded-lg transition">
+              Reservar esta bodega
+            </button>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/pages/warehouseGallery.jsx
+++ b/src/components/pages/warehouseGallery.jsx
@@ -1,122 +1,48 @@
-import { useEffect } from "react";
-import CardWarehouse from "../ui/cardWarehouse";
-
-const customWarehouseData = [
-  {
-    id: 101,
-    size: "6m²",
-    name: "Bodega VIP",
-    location: "Este",
-    price: 2200,
-    features: ["✅ Acceso 24/7", "🪟 Luz natural", "💡 Sensor de movimiento"],
-    image:
-      "https://images.unsplash.com/photo-1624927637280-f033784c1279?w=900&auto=format&fit=crop&q=60",
-  },
-  {
-    id: 102,
-    size: "8m²",
-    name: "Bodega Premium",
-    location: "Centro",
-    price: 2500,
-    features: ["❄️ Climatizado", "🔒 Doble seguridad", "🚗 Estacionamiento"],
-    image:
-      "https://images.unsplash.com/photo-1532635042-a6f6ad4745f9?w=900&auto=format&fit=crop&q=60",
-  },
-  {
-    id: 103,
-    size: "10m²",
-    name: "Bodega Premium",
-    location: "Centro",
-    price: 2500,
-    features: ["❄️ Climatizado", "🔒 Doble seguridad", "🚗 Estacionamiento"],
-    image:
-      "https://images.unsplash.com/photo-1565610222536-ef125c59da2e?w=900&auto=format&fit=crop&q=60",
-  },
-];
+import React from "react";
+import GalleryMasonry from "../ui/galleryMasonry";
+import { motion } from "framer-motion";
 
 export default function WarehouseGallery() {
-  useEffect(() => {
-    import("flowbite").then((m) => m.initCarousels());
-  }, []);
+  const animatedText = "Soluciones de almacenamiento para todos";
 
   return (
-    <div className="pt-16 md:pt-16">
-      <div
-        id="animation-carousel"
-        className="relative w-full"
-        data-carousel="slide" // Cambiado de 'static' a 'slide' para autoplay
-      >
-        {/* Carousel wrapper */}
-        <div className="relative h-56 overflow-hidden md:h-96">
-          {customWarehouseData.map((item, index) => (
-            <div
-              key={item.id}
-              className={`${
-                index === 0 ? "" : "hidden"
-              } duration-200 ease-linear`}
-              data-carousel-item={index === 0 ? "active" : ""}
-            >
-              <img
-                src={item.image}
-                alt={item.name}
-                className="absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2"
-              />
-            </div>
-          ))}
+    <div className="pt-20 px-4 md:px-12 bg-gray-100 min-h-screen">
+      <section className="flex flex-col items-center">
+        <div className="flex max-w-xl flex-col items-center pb-16 pt-8 text-center lg:pb-24 lg:pt-20">
+          <h1 className="mb-8 text-4xl font-bold text-black sm:text-5xl md:mb-12 md:text-6xl">
+            Descubre tu próxima bodega
+          </h1>
+
+          {/* Animación tipo escritura */}
+          <motion.p
+            className="mb-4 font-semibold text-indigo-500 md:mb-6 md:text-lg xl:text-xl flex flex-wrap justify-center"
+            initial="hidden"
+            animate="visible"
+            variants={{
+              visible: {
+                transition: {
+                  staggerChildren: 0.04,
+                },
+              },
+            }}
+          >
+            {animatedText.split("").map((char, index) => (
+              <motion.span
+                key={index}
+                variants={{
+                  hidden: { opacity: 0, y: 5 },
+                  visible: { opacity: 1, y: 0 },
+                }}
+                transition={{ duration: 0.2 }}
+              >
+                {char === " " ? "\u00A0" : char}
+              </motion.span>
+            ))}
+          </motion.p>
         </div>
+      </section>
 
-        {/* Slider controls */}
-        <button
-          type="button"
-          className="absolute top-0 start-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none"
-          data-carousel-prev
-        >
-          <span className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-blue-600 group-hover:bg-white/50 dark:group-hover:bg-blue-700 group-focus:ring-4 group-focus:ring-white dark:group-focus:ring-gray-800/70">
-            <svg
-              className="w-4 h-4 text-white rtl:rotate-180"
-              fill="none"
-              viewBox="0 0 6 10"
-            >
-              <path
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M5 1 1 5l4 4"
-              />
-            </svg>
-            <span className="sr-only">Previous</span>
-          </span>
-        </button>
-
-        <button
-          type="button"
-          className="absolute top-0 end-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none"
-          data-carousel-next
-        >
-          <span className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-blue-600 group-hover:bg-white/50 dark:group-hover:bg-blue-700 group-focus:ring-4 group-focus:ring-white dark:group-focus:ring-gray-800/70">
-            <svg
-              className="w-4 h-4 text-white rtl:rotate-180"
-              fill="none"
-              viewBox="0 0 6 10"
-            >
-              <path
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="m1 9 4-4-4-4"
-              />
-            </svg>
-            <span className="sr-only">Next</span>
-          </span>
-        </button>
-      </div>
-
-      {/* Cards abajo */}
-      <div className="px-6 mt-8">
-        <CardWarehouse data={customWarehouseData} />
-      </div>
+      <GalleryMasonry />
     </div>
   );
 }

--- a/src/components/ui/galleryMasonry.jsx
+++ b/src/components/ui/galleryMasonry.jsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const warehouseImages = [
+  {
+    id: 101,
+    image:
+      "https://images.unsplash.com/photo-1624927637280-f033784c1279?w=900&auto=format&fit=crop&q=60",
+    price: 2200,
+    location: "Este",
+  },
+  {
+    id: 102,
+    image:
+      "https://images.unsplash.com/photo-1532635042-a6f6ad4745f9?w=900&auto=format&fit=crop&q=60",
+    price: 2500,
+    location: "Centro",
+  },
+  {
+    id: 103,
+    image:
+      "https://images.unsplash.com/photo-1565610222536-ef125c59da2e?w=900&auto=format&fit=crop&q=60",
+    price: 2500,
+    location: "Centro",
+  },
+  {
+    id: 104,
+    image:
+      "https://images.unsplash.com/photo-1581291518857-4e27b48ff24e?w=900&auto=format&fit=crop&q=60",
+    price: 2300,
+    location: "Norte",
+  },
+  {
+    id: 105,
+    image:
+      "https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=900&auto=format&fit=crop&q=60",
+    price: 2100,
+    location: "Sur",
+  },
+  {
+    id: 106,
+    image:
+      "https://images.unsplash.com/photo-1571171637578-41bc2dd41cd2?w=900&auto=format&fit=crop&q=60",
+    price: 1900,
+    location: "Oeste",
+  },
+  {
+    id: 107,
+    image:
+      "https://images.unsplash.com/photo-1624927637280-f033784c1279?w=900&auto=format&fit=crop&q=60",
+    price: 1800,
+    location: "Norte",
+  },
+  {
+    id: 108,
+    image:
+      "https://images.unsplash.com/photo-1624927637280-f033784c1279?w=900&auto=format&fit=crop&q=60",
+    price: 1700,
+    location: "Centro",
+  },
+];
+
+const heightOptions = ["h-40", "h-52", "h-64", "h-80", "h-96"];
+
+export default function GalleryMasonry() {
+  const navigate = useNavigate();
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  return (
+    <div className="p-6 min-h-screen">
+      {/* Galería estilo Masonry */}
+      <div className="columns-1 sm:columns-2 md:columns-3 gap-4 space-y-4">
+        {warehouseImages.map((img, idx) => (
+          <div
+            key={img.id}
+            className="relative break-inside-avoid rounded-lg overflow-hidden cursor-pointer transition-transform hover:scale-105 duration-300 group"
+          >
+            <img
+              src={img.image}
+              alt={`Bodega ${img.id}`}
+              className={`w-full rounded-lg object-cover ${
+                heightOptions[idx % heightOptions.length]
+              }`}
+            />
+            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-end p-4">
+              <p className="text-white font-semibold">📍 {img.location}</p>
+              <p className="text-white text-sm mb-2">💰 ${img.price} /mes</p>
+              <button
+                onClick={() => navigate(`/warehouse/${img.id}`)}
+                className="bg-blue-600 text-white px-3 py-1 text-sm rounded hover:bg-blue-700 cursor-pointer"
+              >
+                Ver más
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Modal Lightbox */}
+      {selectedImage && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+          onClick={() => navigate(`/warehouse/${img.id}`)}
+        >
+          <img
+            src={selectedImage}
+            alt="Ampliada"
+            className="max-w-3xl w-full rounded-lg shadow-lg"
+          />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Introduce a new warehouse detail page to display detailed information about a specific warehouse. Additionally, implement a masonry-style gallery for the warehouse gallery page to improve the visual presentation of warehouse images. The navbar has also been updated to handle navigation to the new detail page and improve styling based on the current route.